### PR TITLE
為納甲解卦增加了“若不明確指定起卦日期的干支，則自動以當前日期補齊的功能”

### DIFF
--- a/ichingshifa/ichingshifa.py
+++ b/ichingshifa/ichingshifa.py
@@ -269,7 +269,10 @@ class Iching():
                 "建月":build_month, 
                 "積算":[list(i) for i in np.array_split(accumulate, 10)]}
     
-    def decode_gua(self, gua, daygangzhi):
+    def decode_gua(self, gua, daygangzhi = None):
+        if daygangzhi is None:
+            now = datetime.datetime.now()
+            daygangzhi = self.gangzhi(int(now.year), int(now.month), int(now.day), int(now.hour))[2]
         fivestars = self.data.get("五星")
         eightgua = self.data.get("數字排八卦")
         sixtyfourgua =  self.data.get("數字排六十四卦")
@@ -351,7 +354,10 @@ class Iching():
                 "積算":[list(i) for i in np.array_split(accumulate, 10)]}
     
     
-    def decode_two_gua(self, bengua, ggua, daygangzhi):
+    def decode_two_gua(self, bengua, ggua, daygangzhi = None):
+        if daygangzhi is None:
+            now = datetime.datetime.now()
+            daygangzhi = self.gangzhi(int(now.year), int(now.month), int(now.day), int(now.hour))[2]
         a = self.decode_gua(bengua, daygangzhi)
         b = self.decode_gua(ggua, daygangzhi)
         try:


### PR DESCRIPTION
近日接觸了您的項目，受益良多！在使用納甲解卦功能時，發現decode_gua函數需要指定起卦日期的干支，雖然嚴謹，但也許稍有不便。故冒然對代碼做出以下修改，使得其在用戶未給出起卦日期的干支時，自動用當前的日期補上，提升易用性。