### PR TITLE
fix: use context manager for pickle.load to prevent file-handle leak

### DIFF
--- a/src/ichingshifa/ichingshifa.py
+++ b/src/ichingshifa/ichingshifa.py
@@ -31,7 +31,8 @@ class Iching():
     def __init__(self):
         base = os.path.abspath(os.path.dirname(__file__))
         path = os.path.join(base, 'data.pkl')
-        self.data = pickle.load(open(path, "rb"))
+        with open(path, "rb") as f:
+            self.data = pickle.load(f)
         self.sixtyfourgua = self.data.get("數字排六十四卦")
         self.sixtyfourgua_description = self.data.get("易經卦爻詳解")
         self.eightgua = self.data.get("八卦數值")

--- a/tests/test_no_file_handle_leak.py
+++ b/tests/test_no_file_handle_leak.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+"""Regression test for file-handle leak in Iching.__init__.
+
+Previously ``Iching`` loaded its pickled data via
+``pickle.load(open(path, "rb"))`` which relies on reference-count finalization
+to close the underlying file. On non-CPython runtimes (or when garbage
+collection is disabled) the handle leaks until interpreter shutdown. The fix
+wraps the ``open`` call in a ``with`` statement so the file is closed
+deterministically.
+
+This test asserts that constructing ``Iching`` emits no ``ResourceWarning``
+(which Python raises for unclosed file objects) even while ``gc`` is disabled,
+so the guard would catch a regression to the old ``pickle.load(open(...))``
+form.
+"""
+from __future__ import annotations
+
+import gc
+import os
+import sys
+import warnings
+
+# Make the in-repo ``src`` layout importable without installing the package.
+_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+_SRC = os.path.join(_ROOT, "src")
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+
+def _construct_iching_under_resource_warning_guard():
+    from ichingshifa.ichingshifa import Iching
+
+    gc_was_enabled = gc.isenabled()
+    gc.disable()
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            instance = Iching()
+        resource_warnings = [w for w in caught if issubclass(w.category, ResourceWarning)]
+        return instance, resource_warnings
+    finally:
+        if gc_was_enabled:
+            gc.enable()
+
+
+def test_iching_init_does_not_leak_file_handle():
+    """Constructing ``Iching`` must not emit a ``ResourceWarning``.
+
+    With ``gc`` disabled, the only way the pickle file gets closed is via an
+    explicit ``close()`` call (which ``with open(...)`` guarantees). If the
+    code regresses to ``pickle.load(open(path, "rb"))`` the open file object
+    becomes unreachable without being closed and Python emits a
+    ``ResourceWarning`` the moment it is collected -- or, since gc is off,
+    at interpreter shutdown. To make the check synchronous we enable the
+    ``always`` warning filter and re-enable gc inside the ``catch_warnings``
+    block via a manual collect step below.
+    """
+    instance, resource_warnings = _construct_iching_under_resource_warning_guard()
+
+    assert instance is not None, "Iching() must return an instance"
+    # The pickle file is loaded into ``self.data``; sanity-check the dict
+    # actually populated (proves the fix still parses the pickle correctly).
+    assert isinstance(instance.data, dict) and instance.data, (
+        "Iching().data should be a non-empty dict loaded from data.pkl"
+    )
+
+    # Force collection of any stray file objects so a leaked handle would
+    # surface as a ResourceWarning right here, not at shutdown.
+    with warnings.catch_warnings(record=True) as post_caught:
+        warnings.simplefilter("always")
+        gc.collect()
+        post_resource_warnings = [
+            w for w in post_caught if issubclass(w.category, ResourceWarning)
+        ]
+
+    all_warnings = resource_warnings + post_resource_warnings
+    assert not all_warnings, (
+        "Iching() leaked a file handle -- got ResourceWarning(s): "
+        + "; ".join(str(w.message) for w in all_warnings)
+    )
+
+
+if __name__ == "__main__":
+    test_iching_init_does_not_leak_file_handle()
+    print("ok")


### PR DESCRIPTION
## Summary

`Iching.__init__` at `src/ichingshifa/ichingshifa.py:34` loads the precomputed data via `pickle.load(open(path, \"rb\"))` without a context manager. The opened file object is never explicitly closed, so the underlying OS file handle leaks until CPython's reference counting collects it (and on PyPy, until a GC cycle).

## Fix

Wrap the `open()` in a `with` block so the handle is released as soon as the pickle finishes loading:

```python
with open(data_path, \"rb\") as f:
    self.data = pickle.load(f)
```

## Test

Added `tests/test_no_file_handle_leak.py`. It disables the GC, wraps `Iching()` in `warnings.catch_warnings(record=True)` with `simplefilter(\"always\")`, and asserts no `ResourceWarning` is emitted. Also sanity-checks `instance.data` parses as a non-empty dict so the behavior is preserved.

- Fix applied: `1 passed`.
- Buggy code reverted locally: test fails with `ResourceWarning: unclosed file <_io.BufferedReader name='.../data.pkl'>` — so it catches real regressions.

## Notes

- No behavior change beyond closing the file deterministically.
- Added a top-level \`tests/\` directory with a pytest-style file since the repo had no tests before. Existing CI (`copilot-setup-steps.yml`) only installs `requirements.txt` and is unaffected.
- Happy to adjust the test location/style if you prefer a different layout.